### PR TITLE
Improved performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "advancedresearch-nano_ecs"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Sven Nilsen <bvssvni@gmail.com>"]
 edition = "2018"
 keywords = ["ecs", "macro", "tiny", "nano", "advancedresearch"]


### PR DESCRIPTION
- Bumped to 0.4.0
- Reduced component access to a single liner
- Removed mask map, let LLVM optimize inner loop