### PR TITLE
Fixed bug in `MaskStorage::update`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "advancedresearch-nano_ecs"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Sven Nilsen <bvssvni@gmail.com>"]
 edition = "2018"
 keywords = ["ecs", "macro", "tiny", "nano", "advancedresearch"]


### PR DESCRIPTION
- Bumped to 0.8.0
- `World::disable_component_index`
- Added `World::enable_component_index`

Fixed a bug in `MaskStorage::update` that was caused by not handling a
small edge case properly. When the mask range is the last, there should
be no inserted mask range after it.